### PR TITLE
Fix Rails 5.1 env deprecation warning

### DIFF
--- a/lib/devise_openid_authenticatable/controller.rb
+++ b/lib/devise_openid_authenticatable/controller.rb
@@ -12,7 +12,7 @@ module DeviseOpenidAuthenticatable
     end
 
     def openid_provider_response?
-      !!env[Rack::OpenID::RESPONSE]
+      !!request.env[Rack::OpenID::RESPONSE]
     end
   end
 end


### PR DESCRIPTION
Warning message prior fix:

```
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1 (called from openid_provider_response? at /usr/local/lib/ruby/gems/2.4.0/gems/devise_openid_authenticatable-1.3.0/lib/devise_openid_authenticatable/controller.rb:15)
```

![screen shot 2017-03-16 at 9 55 04 pm](https://cloud.githubusercontent.com/assets/116972/23999570/c9ed4b9e-0a93-11e7-9c7c-ac6f017dbdf3.png)